### PR TITLE
Parallel make

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -34,7 +34,7 @@ To get and compile the latest git version, run:
 
     git clone https://github.com/fenderglass/Flye
     cd Flye
-    make
+    make -j
 
 Then, Flye will be available as:
 

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,13 @@ class MakeBuild(DistutilsBuild):
         if not find_executable("make"):
             sys.exit("ERROR: 'make' command is unavailable")
         try:
-            subprocess.check_call(["make"])
+            # MAX_JOBS controls the number of core used to build,
+            # it uses all available cores by default.
+            make_cmd = ["make", "-j"]
+            if os.environ.get('MAX_JOBS'):
+                make_cmd.append(os.environ.get('MAX_JOBS'))
+
+            subprocess.check_call(make_cmd)
         except subprocess.CalledProcessError as e:
             sys.exit("Compilation error: ", e)
 


### PR DESCRIPTION
Use available cores to speed up build. By default, it uses all cores available but one can specify
```
MAX_JOBS=2 python setup.py install
```
to build only 2 object concurrently.