### PR TITLE
sequence_container: free buffer when failing to open compressed file.

### DIFF
--- a/src/sequence/sequence_container.cpp
+++ b/src/sequence/sequence_container.cpp
@@ -150,6 +150,7 @@ size_t SequenceContainer::readFasta(std::vector<FastaRecord>& record,
 	auto* fd = gzopen(fileName.c_str(), "rb");
 	if (!fd)
 	{
+		delete[] rawBuffer;
 		throw ParseException("Can't open reads file");
 	}
 
@@ -235,6 +236,7 @@ size_t SequenceContainer::readFastq(std::vector<FastaRecord>& record,
 	auto* fd = gzopen(fileName.c_str(), "rb");
 	if (!fd)
 	{
+		delete[] rawBuffer;
 		throw ParseException("Can't open reads file");
 	}
 


### PR DESCRIPTION
A buffer was allocated to read from the file, but was not freed when gzopen failed to open it.
Even though the program exists just after the exception, freeing it will reduce the nb of warning from static analysis tools like cppcheck.