### PR TITLE
Successfully build wheels

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,9 @@ class MakeInstall(SetuptoolsInstall):
             sys.exit('Error: no write permission for ' + self.install_scripts + '  ' +
                      'Perhaps you need to use sudo?')
 
+        if not os.path.exists(self.install_scripts):
+            os.makedirs(self.install_scripts)
+
         build_dir = os.path.join(script_dir, "bin")
         install_dir = self.install_scripts
         bin_files = ['flye-modules', 'flye-minimap2', 'flye-samtools']


### PR DESCRIPTION
See https://github.com/fenderglass/Flye/issues/190

This fixes an issue where the install_scripts directory is not created
during the install process (due to the package not containing any
install scripts), but it does rely on the install_directories to
manually install binaries. Fix the manual binary copying logic to check
for the existence of the install_scripts directory and create it if
necessary

`python setup.py bdist_wheel` should work after this. Additionally, pip
installing the package (even if no wheel exists) will succeed at
generating the wheel dynamically.