### PR TITLE
Fix for 'make clean' failing on pristine sources

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,5 +39,5 @@ clean:
 	make clean -C src
 	make clean -C ${MINIMAP2_DIR}
 	make clean-all -C ${SAMTOOLS_DIR}
-	rm ${BIN_DIR}/flye-minimap2
-	rm ${BIN_DIR}/flye-samtools
+	rm -f ${BIN_DIR}/flye-minimap2
+	rm -f ${BIN_DIR}/flye-samtools

--- a/src/Makefile
+++ b/src/Makefile
@@ -63,10 +63,10 @@ main.o: main.cpp
 
 
 clean:
-	-rm ${repeat_obj}
-	-rm ${sequence_obj}
-	-rm ${assemble_obj}
-	-rm ${polish_obj}
-	-rm ${contigger_obj}
-	-rm ${main_obj}
-	-rm ${MODULES_BIN}
+	rm -f ${repeat_obj}
+	rm -f ${sequence_obj}
+	rm -f ${assemble_obj}
+	rm -f ${polish_obj}
+	rm -f ${contigger_obj}
+	rm -f ${main_obj}
+	rm -f ${MODULES_BIN}


### PR DESCRIPTION
Currently a fresh checkout of the project fails `make clean && make`. This is due to `rm` commands in the `clean` targets that fail on non-existing files.

This commit replaces the `rm` and `-rm` in the `clean` targets with `rm -f`, which won't fail if the targeted file is absent.