### PR TITLE
Add --deterministic argument to run disjointig assembly single-threaded

### DIFF
--- a/flye/assembly/assemble.py
+++ b/flye/assembly/assemble.py
@@ -41,7 +41,7 @@ def assemble(args, run_params, out_file, log_file, config_path):
     logger.info("Assembling disjointigs")
     logger.debug("-----Begin assembly log------")
     cmdline = [ASSEMBLE_BIN, "assemble", "--reads", ",".join(args.reads), "--out-asm", out_file,
-               "--config", config_path, "--log", log_file, "--threads", str(args.threads)]
+               "--config", config_path, "--log", log_file, "--threads", str(1 if args.deterministic else args.threads)]
     if args.debug:
         cmdline.append("--debug")
     if args.meta:

--- a/flye/main.py
+++ b/flye/main.py
@@ -619,7 +619,8 @@ def _usage():
             "\t     [--meta] [--polish-target] [--min-overlap SIZE]\n"
             "\t     [--keep-haplotypes] [--debug] [--version] [--help] \n"
             "\t     [--scaffold] [--resume] [--resume-from] [--stop-after] \n"
-            "\t     [--read-error float] [--extra-params]")
+            "\t     [--read-error float] [--extra-params] \n"
+            "\t     [--deterministic]")
 
 
 def _epilog():
@@ -752,6 +753,9 @@ def main():
                         dest="debug", default=False,
                         help="enable debug output")
     parser.add_argument("-v", "--version", action="version", version=_version())
+    parser.add_argument("--deterministic", action="store_true",
+                        dest="deterministic", default=False,
+                        help="perform disjointig assembly single-threaded")
     args = parser.parse_args()
 
     if args.asm_coverage and (args.genome_size is None):


### PR DESCRIPTION
This PR addresses #509 by adding an additional command line argument, `--deterministic`, to enable single-threaded disjointig assembly. From the discussion on that issue, it appears that this is the part of Flye that causes non-deterministic output due to the stochastic nature of OS thread scheduling.