### PR TITLE
Add Jupyter notebook example

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -119,6 +119,11 @@ The dataset was originally released by the
     wget https://zenodo.org/record/1172816/files/Loman_E.coli_MAP006-1_2D_50x.fasta
     flye --nano-raw Loman_E.coli_MAP006-1_2D_50x.fasta --out-dir out_nano --threads 4
 
+### Jupyter notebook with the same examples as above
+
+You can also try Flye assembly with [a Jupyter notebook with the same examples as 
+above](https://biotutorials.org/flye). 
+Simply click the link to open the notebook in your browser, and run the examples there.
 
 ## <a name="inputdata"></a> Supported Input Data
 


### PR DESCRIPTION
This PR adds [a browser-based Jupyter notebook](https://biotutorials.org/flye) example I wrote, with the intent of lowering the bar to try out Flye. It's almost exactly the same as [the examples section of the Flye manual](https://github.com/fenderglass/Flye/blob/flye/docs/USAGE.md#examples), but doesn't require the user to install and set up Flye.

This works by creating a temporary JupyterLab session for each user, and then uses our HPC servers for the computationally intensive commands (i.e. Flye). It's free, can run each example in about 15 minutes, and my hope is that it lowers the bar for novice users to try Flye.

I'm happy to make any changes! The idea started with a MEGAHIT notebook I made for our collaborators that was [later merged](https://www.github.com/voutcn/megahit/pull/350), and seems to have been helpful so far.

Here's a quick screen recording of the notebook spawning in action:

https://user-images.githubusercontent.com/10551613/220808475-b9e53397-cb28-4355-bcd3-b92beffa6621.mov

