### PR TITLE
fix build failure with gcc 13

### DIFF
--- a/src/polishing/subs_matrix.h
+++ b/src/polishing/subs_matrix.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <string>
 #include <fstream>
 #include <iostream>

--- a/src/sequence/sequence_container.h
+++ b/src/sequence/sequence_container.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <vector>
 #include <unordered_map>
 #include <string>


### PR DESCRIPTION
As seen initially in [Debian bug#1037662], per [gcc 13 porting guide], there have been header dependency changes resulting in the following build errors:

	In file included from repeat_graph/repeat_graph.h:10,
	                 from repeat_graph/graph_processing.h:10,
	                 from repeat_graph/graph_processing.cpp:7:
	repeat_graph/../sequence/sequence_container.h:21:37: error: expected ‘)’ before ‘id’
	   21 |                 explicit Id(uint32_t id): _id(id) {}
	      |                            ~        ^~~
	      |                                     )
	repeat_graph/../sequence/sequence_container.h:69:17: error: ‘uint32_t’ does not name a type
	   69 |                 uint32_t _id;
	      |                 ^~~~~~~~
	repeat_graph/../sequence/sequence_container.h:13:1: note: ‘uint32_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?

[…]

	In file included from polishing/alignment.h:14,
	                 from polishing/alignment.cpp:5:
	polishing/subs_matrix.h:47:34: error: ‘uint32_t’ has not been declared
	   47 |                 State(char nucl, uint32_t length);
	      |                                  ^~~~~~~~
	polishing/subs_matrix.h:53:17: error: ‘uint32_t’ does not name a type
	   53 |                 uint32_t length;
	      |                 ^~~~~~~~
	polishing/subs_matrix.h:13:1: note: ‘uint32_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?

Including cstdint in the affect header files fixes the issue.

[Debian bug#1037662]: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1037662
[gcc 13 porting guide]: https://gcc.gnu.org/gcc-13/porting_to.html