### PR TITLE
Move _SixMetaPathImporter to using find_spec()

### DIFF
--- a/flye/six.py
+++ b/flye/six.py
@@ -71,6 +71,10 @@ else:
             MAXSIZE = int((1 << 63) - 1)
         del X
 
+if PY34:
+    from importlib.util import spec_from_loader
+else:
+    spec_from_loader = None
 
 def _add_doc(func, doc):
     """Add documentation to a function."""
@@ -186,6 +190,11 @@ class _SixMetaPathImporter(object):
             return self
         return None
 
+    def find_spec(self, fullname, path, target=None):
+        if fullname in self.known_modules:
+            return spec_from_loader(fullname, self)
+        return None
+
     def __get_module(self, fullname):
         try:
             return self.known_modules[fullname]
@@ -222,6 +231,12 @@ class _SixMetaPathImporter(object):
         self.__get_module(fullname)  # eventually raises ImportError
         return None
     get_source = get_code  # same as get_code
+
+    def create_module(self, spec):
+        return self.load_module(spec.name)
+
+    def exec_module(self, module):
+        pass
 
 _importer = _SixMetaPathImporter(__name__)
 


### PR DESCRIPTION
Python 3.12 seems to have completely done away with find_module(), which the _SixMetaPathImporter still uses. This commit added support for 3.12 through the find_spec() finder approach.

**Credits**: This delta was borrowed from kafka-python project https://github.com/dpkp/kafka-python/blob/master/kafka/vendor/six.py