### PR TITLE
Fix aarch64 builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,10 @@ ifeq ($(shell uname -m),arm64)
 	export aarch64=1
 endif
 
+ifeq ($(shell uname -m),aarch64)
+	export aarch64=1
+endif
+
 .PHONY: clean all profile debug minimap2 samtools
 
 .DEFAULT_GOAL := all


### PR DESCRIPTION
Building failed on `aarch64` machines when `uname -m` reported `aarch64` instead of `arm64`.