### PR TITLE
remove deprecated distutils usage

### DIFF
--- a/flye/tests/test_toy.py
+++ b/flye/tests/test_toy.py
@@ -15,11 +15,10 @@ import os
 import sys
 import subprocess
 import shutil
-from distutils.spawn import find_executable
 
 
 def test_toy():
-    if not find_executable("flye"):
+    if not shutil.which("flye"):
         sys.exit("flye is not installed!")
 
     print("Running toy test:\n")


### PR DESCRIPTION
`distutils.spawn.find_executable` is a deprecated function and it is recommended to use `shutil.which` instead.

see https://peps.python.org/pep-0632/#migration-advice

Note that `distutils` are no longer available in Python 3.12.