### PR TITLE
Update main.py to accomodate up to 1024 threads

### DIFF
--- a/flye/main.py
+++ b/flye/main.py
@@ -614,7 +614,7 @@ def main():
                         default=None, required=True,
                         metavar="path", help="Output directory")
     parser.add_argument("-t", "--threads", dest="threads",
-                        type=lambda v: check_int_range(v, 1, 128),
+                        type=lambda v: check_int_range(v, 1, 1024),
                         default=1, metavar="int", help="number of parallel threads [1]")
     parser.add_argument("-i", "--iterations", dest="num_iters",
                         type=lambda v: check_int_range(v, 0, 10),


### PR DESCRIPTION
I ran into a max 128 threads on a 192 core machine. The pipeline I use (hybracter) assigns the max nr of cores to the flye assembly snakemake rule. This 'fix' seems to work for 192 threads'.