### PR TITLE
Fix chimera detector overlap sampling mismatch causing 0 disjointigs at high coverage

### DIFF
--- a/src/assemble/extender.cpp
+++ b/src/assemble/extender.cpp
@@ -283,7 +283,7 @@ void Extender::assembleDisjointigs()
 		//store overlap information for many trashy reads
 		//that won't result into disjointig extension
 		auto startOvlps = _ovlpContainer.quickSeqOverlaps(startRead, 
-														  /*max overlaps*/ 100);
+														  /*max overlaps*/ 0);
 		int numInnerOvlp = 0;
 		int totalOverlaps = 0;
 		for (const auto& ovlp : IterNoOverhang(startOvlps))


### PR DESCRIPTION
Fixes #128 Fixes #791 (and related: #708, #748)

### Problem

Flye assembles 0 disjointigs when overlap coverage exceeds ~500x due to a mismatch between the chimera coverage estimator and the chimera test:

- `estimateGlobalCoverage()` uses `lazySeqOverlaps()` → ALL overlaps → `_overlapCoverage`
- `testReadByCoverage()` receives `quickSeqOverlaps(startRead, 100)` → max 100 overlaps
- When `_overlapCoverage > 100 × max_coverage_drop_rate (= 500)`, the chimera threshold exceeds the max per-window coverage achievable from 100 overlaps
- Result: ALL reads flagged chimeric → 0 disjointigs

### Fix

Change `quickSeqOverlaps(startRead, 100)` → `quickSeqOverlaps(startRead, 0)` in `src/assemble/extender.cpp:286`.

With `maxOverlaps=0` (unlimited), the chimera test receives the same overlap set as the coverage estimator, ensuring consistent per-window coverage values.

### Testing

Tested with 767 ONT reads from a 5.3 kb amplicon at 683x overlap coverage:

| | Before | After |
|---|--------|-------|
| Disjointigs | **0** (FAIL) | **2** (SUCCESS) |
| Final contigs | — | 1 |
| Assembly length | — | 5,312 bp |

Also tested at normal coverage (~30x via `--asm-coverage 50`): no regression, identical assembly produced.

### Performance Impact

`quickSeqOverlaps` computes overlaps on-the-fly without caching (unlike `lazySeqOverlaps`). At normal coverage (30-100x), reads have ~30-100 overlaps, so the 100 limit was never hit — no performance change. At high coverage, removing the limit increases per-read overlap computation, but this is necessary for correctness.

### Alternative Approaches Considered

1. **Cap the threshold** (`threshold = min(threshold, maxQuickOverlaps / 2)`) — preserves the optimization but adds coupling between extender.cpp and chimera.cpp
2. **Dynamic limit** (`maxQuick = max(100, coverage * 2)`) — more complex, similar effect
3. **Use `lazySeqOverlaps` for chimera test** — would cache overlaps for all reads, increasing memory

This fix (removing the limit) is the simplest and most direct approach.

### Commits

- `f5f73a60` fix: remove quickSeqOverlaps limit to prevent chimera false positives at high coverage
